### PR TITLE
Install pre-release of astroquery

### DIFF
--- a/etc/jwstdp-snapshot/pip/005-suppl
+++ b/etc/jwstdp-snapshot/pip/005-suppl
@@ -1,1 +1,1 @@
-astroquery
+--pre astroquery


### PR DESCRIPTION
`astroquery` has continuous deployment. Is this the correct incantation to pick that up, @jhunkeler ?

On a terminal, one would do `pip install astroquery --pre`.